### PR TITLE
#8 Handle ListItem in MarkDownconvertor

### DIFF
--- a/UniversalPackageExplorer/Converters/MarkdownConverter.cs
+++ b/UniversalPackageExplorer/Converters/MarkdownConverter.cs
@@ -35,6 +35,7 @@ namespace UniversalPackageExplorer.Converters
                 case BlockTag.BlockQuote:
                     return new Section(Fill(block.FirstChild)) { Margin = new Thickness(20, 0, 20, 0) };
                 case BlockTag.List:
+                case BlockTag.ListItem:
                     var list = new List();
                     var item = block.FirstChild;
                     while (item != null)


### PR DESCRIPTION
Fixes #8 (well it fixes the program crashing. The formatting is still a bit odd)

Also, I had some trouble building the solution from source as the following NuGet packages couldn't be found on nuget.org:
- Interop.IWshRuntimeLibrary.1.0.0
- Inedo.Installer.43.0.0
- Inedo.UPack.0.1.0-pre0032

To build locally I updated Inedo.Upack to v1.0.6 and unloaded the Setup and Unistaller projects. I don;t know if this needs a separate issue to resolve - happy to do so but I would need to know which versions would need to be used.
